### PR TITLE
Fix ObjectComplementOf handling and enable wasm32 builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,12 @@ edition = "2021"
 [dependencies]
 clap = { version = "^4.1", features = ["derive"] }
 env_logger = "^0.10"
-horned-owl = "^1.4"
+# default-features = false drops horned-owl's `remote` feature (its ureq-based
+# import resolver), which whelk never uses — it only calls the owx/rdf readers
+# and the object model. Dropping it keeps ureq/rustls out of the graph so whelk
+# builds for wasm32 (used as the `--reasoner whelk` backend in owlmake's browser
+# build); the parsers' clock comes from horned-owl's own wasm-safe `web-time`.
+horned-owl = { version = "^1.4", default-features = false }
 humantime = "^2.0"
 im = "^15.1"
 itertools = "^0.10"

--- a/src/whelk/reasoner.rs
+++ b/src/whelk/reasoner.rs
@@ -144,7 +144,8 @@ pub fn assert_append(axioms: &HashSet<ConceptInclusion>, state: &ReasonerState) 
                 }
             }
             ConceptData::Complement(inner) => {
-                additional_axioms.insert(rule_complement(inner, new_state.bottom));
+                let bottom = new_state.bottom;
+                additional_axioms.insert(rule_complement(c, inner, bottom, &mut new_state.interner));
             }
             _ => {}
         }
@@ -669,9 +670,22 @@ fn rule_union(disjunction_id: ConceptId, operands: &HashSet<ConceptId>) -> Vec<C
         .collect()
 }
 
-fn rule_complement(inner: ConceptId, bottom: ConceptId) -> ConceptInclusion {
+/// `¬B` is not an EL concept, but the constraint it places on the rest of the
+/// ontology is: nothing is both `B` and `¬B`. Emit exactly that, as the
+/// disjointness `B ⊓ ¬B ⊑ ⊥`, and let the conjunction rules derive `X ⊑ ⊥` for
+/// an `X` that is actually shown to be both.
+///
+/// Asserting the far stronger `B ⊑ ⊥` instead makes every complemented class
+/// unsatisfiable on sight — and OBO ontologies complement freely (NCBITaxon's
+/// disjoint-over-`in taxon` axioms alone put ~2.3k `ObjectComplementOf` into
+/// CL's import closure), so that collapses most of the ontology.
+fn rule_complement(complement: ConceptId, inner: ConceptId, bottom: ConceptId, interner: &mut Interner) -> ConceptInclusion {
+    let conjunction = interner.intern_concept(ConceptData::Conjunction {
+        left: inner,
+        right: complement,
+    });
     ConceptInclusion {
-        subclass: inner,
+        subclass: conjunction,
         superclass: bottom,
     }
 }


### PR DESCRIPTION
Two independent changes to whelk-rs.

## Encode `ObjectComplementOf` as disjointness rather than `B ⊑ ⊥`

`rule_complement` previously asserted `inner ⊑ ⊥` for every `¬B` reached during
translation — declaring every class named under an `ObjectComplementOf`
unsatisfiable on sight.

`¬B` is not an EL concept, but the constraint it imposes is EL-expressible:
nothing can be both `B` and `¬B`. This emits that as the disjointness
`B ⊓ ¬B ⊑ ⊥` and lets the existing conjunction rules
(`rule_plus_and_a` / `rule_plus_and_b`) derive `X ⊑ ⊥` only for an `X` actually
shown to be both.

The old behaviour made whelk unusable on real OBO ontologies, which use
complement freely. NCBITaxon's disjoint-over-`in taxon` axioms alone contribute
~2,300 `ObjectComplementOf` to the Cell Ontology's import closure, and
classifying CL reported 15,319 of ~19,000 classes unsatisfiable — including
`CL:0000000` (cell), the root. Downstream this is worse than a crash: a
`reduce` pass correctly treats every subclass axiom of an unsatisfiable class as
redundant, so a release pipeline silently emits artefacts with the hierarchy
stripped out. With this change CL classifies coherently and agrees with ELK.

## Drop horned-owl's default `remote` feature so whelk builds for wasm

whelk only uses horned-owl's owx/rdf readers and object model, never its
`remote` import resolver (ureq/rustls). Requesting horned-owl with
`default-features = false` keeps ureq/rustls out of the dependency graph,
letting the crate compile for `wasm32-unknown-unknown` — so it can serve as the
`--reasoner whelk` backend in owlmake's browser (wasm) build, not just native.
The owx/rdf parsers' clock comes from horned-owl's own wasm-safe `web-time`.